### PR TITLE
Generate loot tables and remove the getDroppedStacks override

### DIFF
--- a/src/main/java/vivatech/block/AbstractMachineBlock.java
+++ b/src/main/java/vivatech/block/AbstractMachineBlock.java
@@ -16,10 +16,9 @@ import net.minecraft.util.ItemScatterer;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Direction;
 import net.minecraft.world.World;
-import vivatech.energy.EnergyAttributeProvider;
 import vivatech.entity.AbstractMachineEntity;
 
-public abstract class AbstractMachineBlock extends BaseBlock implements BlockEntityProvider, AttributeProvider {
+public abstract class AbstractMachineBlock extends Block implements BlockEntityProvider, AttributeProvider {
     public static final DirectionProperty FACING = Properties.FACING_HORIZONTAL;
     public static final BooleanProperty ACTIVE = BooleanProperty.create("active");
 

--- a/src/main/java/vivatech/block/BaseBlock.java
+++ b/src/main/java/vivatech/block/BaseBlock.java
@@ -1,9 +1,0 @@
-package vivatech.block;
-
-import net.minecraft.block.Block;
-
-public class BaseBlock extends Block {
-    public BaseBlock(Settings settings) {
-        super(settings);
-    }
-}

--- a/src/main/java/vivatech/block/BaseBlock.java
+++ b/src/main/java/vivatech/block/BaseBlock.java
@@ -1,21 +1,9 @@
 package vivatech.block;
 
-import com.google.common.collect.Lists;
 import net.minecraft.block.Block;
-import net.minecraft.block.BlockState;
-import net.minecraft.item.ItemStack;
-import net.minecraft.world.loot.context.LootContext;
-
-import java.util.List;
 
 public class BaseBlock extends Block {
     public BaseBlock(Settings settings) {
         super(settings);
-    }
-
-    // Block
-    @Override
-    public List<ItemStack> getDroppedStacks(BlockState state, LootContext.Builder builder) {
-        return Lists.newArrayList(new ItemStack(asItem()));
     }
 }

--- a/src/main/java/vivatech/init/VivatechBlocks.java
+++ b/src/main/java/vivatech/init/VivatechBlocks.java
@@ -1,5 +1,6 @@
 package vivatech.init;
 
+import net.minecraft.block.Block;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.registry.Registry;
 import vivatech.Vivatech;
@@ -8,7 +9,7 @@ import vivatech.block.*;
 public class VivatechBlocks implements Initializable {
     public static final Identifier MACHINE_CHASSIS_ID = new Identifier(Vivatech.MODID, "machine_chassis");
 
-    public static final BaseBlock MACHINE_CHASSIS;
+    public static final Block MACHINE_CHASSIS;
     public static final EnergyConduitBlock ENERGY_CONDUIT;
     public static final CoalGeneratorBlock COAL_GENERATOR;
     public static final CrusherBlock CRUSHER;
@@ -17,7 +18,7 @@ public class VivatechBlocks implements Initializable {
     public static final PressBlock PRESS;
 
     static {
-        MACHINE_CHASSIS = new BaseBlock(Vivatech.METALLIC_BLOCK_SETTINGS);
+        MACHINE_CHASSIS = new Block(Vivatech.METALLIC_BLOCK_SETTINGS);
         ENERGY_CONDUIT = new EnergyConduitBlock();
         COAL_GENERATOR = new CoalGeneratorBlock();
         CRUSHER = new CrusherBlock();

--- a/src/main/resources/assets/vivatech/models/block/energy_conduit_center.json
+++ b/src/main/resources/assets/vivatech/models/block/energy_conduit_center.json
@@ -1,5 +1,6 @@
 {
 	"credit": "Made with Blockbench",
+	"parent": "minecraft:block/block",
 	"textures": {
 		"0": "vivatech:block/energy_conduit",
 		"particle": "vivatech:block/energy_conduit"

--- a/src/main/resources/data/vivatech/loot_tables/blocks/coal_generator.json
+++ b/src/main/resources/data/vivatech/loot_tables/blocks/coal_generator.json
@@ -1,0 +1,19 @@
+{
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "vivatech:coal_generator"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ]
+    }
+  ],
+  "type": "minecraft:block"
+}

--- a/src/main/resources/data/vivatech/loot_tables/blocks/crusher.json
+++ b/src/main/resources/data/vivatech/loot_tables/blocks/crusher.json
@@ -1,0 +1,19 @@
+{
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "vivatech:crusher"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ]
+    }
+  ],
+  "type": "minecraft:block"
+}

--- a/src/main/resources/data/vivatech/loot_tables/blocks/electric_furnace.json
+++ b/src/main/resources/data/vivatech/loot_tables/blocks/electric_furnace.json
@@ -1,0 +1,19 @@
+{
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "vivatech:electric_furnace"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ]
+    }
+  ],
+  "type": "minecraft:block"
+}

--- a/src/main/resources/data/vivatech/loot_tables/blocks/energy_bank.json
+++ b/src/main/resources/data/vivatech/loot_tables/blocks/energy_bank.json
@@ -1,0 +1,19 @@
+{
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "vivatech:energy_bank"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ]
+    }
+  ],
+  "type": "minecraft:block"
+}

--- a/src/main/resources/data/vivatech/loot_tables/blocks/energy_conduit.json
+++ b/src/main/resources/data/vivatech/loot_tables/blocks/energy_conduit.json
@@ -1,0 +1,19 @@
+{
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "vivatech:energy_conduit"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ]
+    }
+  ],
+  "type": "minecraft:block"
+}

--- a/src/main/resources/data/vivatech/loot_tables/blocks/machine_chassis.json
+++ b/src/main/resources/data/vivatech/loot_tables/blocks/machine_chassis.json
@@ -1,0 +1,19 @@
+{
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "vivatech:machine_chassis"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ]
+    }
+  ],
+  "type": "minecraft:block"
+}

--- a/src/main/resources/data/vivatech/loot_tables/blocks/press.json
+++ b/src/main/resources/data/vivatech/loot_tables/blocks/press.json
@@ -1,0 +1,19 @@
+{
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "vivatech:press"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ]
+    }
+  ],
+  "type": "minecraft:block"
+}


### PR DESCRIPTION
Also includes a loot table for energy conduits, which didn't drop anything before.