### PR TITLE
Type safety, and short-circuit on the cheap condition if possible

### DIFF
--- a/src/main/java/vivatech/block/EnergyConduitBlock.java
+++ b/src/main/java/vivatech/block/EnergyConduitBlock.java
@@ -160,9 +160,9 @@ public class EnergyConduitBlock extends Block implements BlockEntityProvider, At
 
         public boolean canConnect(Direction direction) {
             BlockPos offsetPos = pos.offset(direction);
-            SearchOption option = SearchOptions.inDirection(direction);
-            return EnergyAttribute.ENERGY_ATTRIBUTE.getFirstOrNull(world, offsetPos, option) != null
-                    || world.getBlockState(offsetPos).getBlock() instanceof EnergyConduitBlock;
+            SearchOption<Object> option = SearchOptions.inDirection(direction);
+            return world.getBlockState(offsetPos).getBlock() instanceof EnergyConduitBlock
+            		|| EnergyAttribute.ENERGY_ATTRIBUTE.getFirstOrNull(world, offsetPos, option) != null;
         }
     }
 


### PR DESCRIPTION
Changes proposed in this pull request:
  - Short-circuit cable connection logic to the cheap condition (checking if it's a cable block) if possible
  - Adding type parameter to the SearchOptions - even though it doesn't look right, Object is correct because it comes from `SearchOptions.inDirection`, and `Object` satisfies `? super T` because `Object` is a super of `T` (in this case, EnergyAttribute).