### PR TITLE
Temp fixes for copper ore on surface and iron dust not being smelted

### DIFF
--- a/src/main/resources/data/vivatech/oregen/metals.json5
+++ b/src/main/resources/data/vivatech/oregen/metals.json5
@@ -1,0 +1,19 @@
+{
+  "generators": {
+    "copper": {
+      "dimensions": [
+        {
+          "tag": "overworlds"
+        }
+      ],
+      "biomes": [
+        "*"
+      ],
+      "ore_block": "c:copper_ore",
+      "min_height": 20,
+      "max_height": 54,
+      "cluster_count": 20,
+      "cluster_size": 10
+    }
+  }
+}

--- a/src/main/resources/data/vivatech/recipes/iron_ingot_from_blasting.json
+++ b/src/main/resources/data/vivatech/recipes/iron_ingot_from_blasting.json
@@ -1,0 +1,9 @@
+{
+  "type": "minecraft:blasting",
+  "ingredient": {
+    "tag": "c:iron_dust"
+  },
+  "result": "minecraft:iron_ingot",
+  "experience": 0.7,
+  "cookingtime": 200
+}

--- a/src/main/resources/data/vivatech/recipes/iron_ingot_from_smelting.json
+++ b/src/main/resources/data/vivatech/recipes/iron_ingot_from_smelting.json
@@ -1,0 +1,9 @@
+{
+  "type": "minecraft:smelting",
+  "ingredient": {
+    "tag": "c:iron_dust"
+  },
+  "result": "minecraft:iron_ingot",
+  "experience": 0.7,
+  "cookingtime": 200
+}


### PR DESCRIPTION
These are only temporary untill Cotton Resources are updated. The copper issue can be fixed by not allowing it to replace dirt/grass so that it can still spawn in mountain sides.


Changes proposed in this pull request:
  - This fix makes it so copper only spawn below y level 54.
  - This fix adds recipies for smelting and blasting dust.
Note that blasting and smelting have the same cooking times throughout all dusts which is weird.